### PR TITLE
dev-fia-empty-timeseries: prevent FIA from throwing an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 [//]: # (Note that version headers need to start with "# " characters to be picked up by some automated scripts)
 
+# 3.3.1
+
+### Bug Fixes
+
+* Prevent FIA from throwing an exception when an empty time series is returned.
+
 # 3.3
 
 ### Features

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cmclinnovations</groupId>
     <artifactId>feature-info-agent</artifactId>
-    <version>3.3</version>
+    <version>3.3.1</version>
     <packaging>war</packaging>
 
     <!-- Project properties -->
@@ -31,7 +31,7 @@
     <parent>
         <groupId>uk.ac.cam.cares.jps</groupId>
         <artifactId>jps-parent-pom</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1</version>
     </parent>
 
     <!-- Profiles are used to switch between building for development and production 
@@ -180,7 +180,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.5.5</version>
+            <version>1.40.1</version>
         </dependency>
 
         <!-- Java servlet API, version pulled from parent -->

--- a/code/src/main/java/com/cmclinnovations/featureinfo/config/StackInteractor.java
+++ b/code/src/main/java/com/cmclinnovations/featureinfo/config/StackInteractor.java
@@ -16,7 +16,7 @@ import com.cmclinnovations.stack.clients.postgis.PostGISEndpointConfig;
  * stack client library.
  */
 public class StackInteractor extends ContainerClient {
-    
+
     /**
      * Logger for reporting info/errors.
      */
@@ -42,7 +42,8 @@ public class StackInteractor extends ContainerClient {
     }
 
     /**
-     * Uses the TWA Stack client library to determine all Ontop, PostgreSQL, and Blazegraph
+     * Uses the TWA Stack client library to determine all Ontop, PostgreSQL, and
+     * Blazegraph
      * endpoints within the current stack instance.
      */
     public void discoverEndpoints() {
@@ -61,11 +62,10 @@ public class StackInteractor extends ContainerClient {
 
         OntopEndpointConfig ontopConfig = readEndpointConfig("ontop", OntopEndpointConfig.class);
         ontopEndpoints.add(new StackEndpoint(
-            ontopConfig.getUrl(),
-            ontopConfig.getUsername(),
-            ontopConfig.getPassword(),
-            StackEndpointType.ONTOP
-        ));
+                ontopConfig.getUrl(),
+                null,
+                null,
+                StackEndpointType.ONTOP));
 
         LOGGER.info("Have discovered a local Ontop endpoint: {}", ontopConfig.getUrl());
         return ontopEndpoints;
@@ -81,11 +81,10 @@ public class StackInteractor extends ContainerClient {
 
         RDB_CONFIG = readEndpointConfig("postgis", PostGISEndpointConfig.class);
         postgresEndpoints.add(new StackEndpoint(
-            RDB_CONFIG.getJdbcDriverURL(),
-            RDB_CONFIG.getUsername(),
-            RDB_CONFIG.getPassword(),
-            StackEndpointType.POSTGRES
-        ));
+                RDB_CONFIG.getJdbcDriverURL(),
+                RDB_CONFIG.getUsername(),
+                RDB_CONFIG.getPassword(),
+                StackEndpointType.POSTGRES));
 
         LOGGER.info("Have discovered a local Ontop endpoint: {}", RDB_CONFIG.getJdbcDriverURL());
         return postgresEndpoints;
@@ -103,16 +102,15 @@ public class StackInteractor extends ContainerClient {
         // Rather than asking the stack client library, ask Blazegraph itself to
         // tell use the URL endpoint for each of its namespaces.
         NamespaceGetter getter = new NamespaceGetter(
-            blazeConfig.getServiceUrl(),
-            blazeConfig.getUsername(),
-            blazeConfig.getPassword()
-        );
+                blazeConfig.getServiceUrl(),
+                blazeConfig.getUsername(),
+                blazeConfig.getPassword());
 
         // Run logic to query for namespaces
         try {
             List<StackEndpoint> blazegraphEndpoints = getter.discoverEndpoints();
             return blazegraphEndpoints;
-        } catch(Exception exception) {
+        } catch (Exception exception) {
             LOGGER.error("Could not contact Blazegraph to determine namespace URLs!", exception);
             return new ArrayList<>();
         }
@@ -126,12 +124,11 @@ public class StackInteractor extends ContainerClient {
     public static String generatePostgresURL(String dbName) {
         try {
             return RDB_CONFIG.getJdbcURL(dbName);
-        } catch(RuntimeException exception) {
+        } catch (RuntimeException exception) {
             // Probably not running within a stack
             return "";
         }
     }
-
 
 }
 // End of class.

--- a/code/src/main/java/com/cmclinnovations/featureinfo/core/time/TimeHandler.java
+++ b/code/src/main/java/com/cmclinnovations/featureinfo/core/time/TimeHandler.java
@@ -385,16 +385,24 @@ public class TimeHandler {
 
             case LATEST: {
                 TimeSeries<Instant> latest = this.tsClient.getLatestData(measureIRI, connection);
-                Instant boundOne = latest.getTimes().get(0);
-                Instant boundTwo = offsetTime(timeLimit * -1, timeUnit, boundOne);
-                return new ImmutablePair<>(boundOne, boundTwo);
+                if (latest.getTimes().isEmpty()) {
+                    return null;
+                } else {
+                    Instant boundOne = latest.getTimes().get(0);
+                    Instant boundTwo = offsetTime(timeLimit * -1, timeUnit, boundOne);
+                    return new ImmutablePair<>(boundOne, boundTwo);
+                }
             }
 
             case FIRST: {
                 TimeSeries<Instant> first = this.tsClient.getOldestData(measureIRI, connection);
-                Instant boundOne = first.getTimes().get(0);
-                Instant boundTwo = offsetTime(timeLimit, timeUnit, boundOne);
-                return new ImmutablePair<>(boundOne, boundTwo);
+                if (first.getTimes().isEmpty()) {
+                    return null;
+                } else {
+                    Instant boundOne = first.getTimes().get(0);
+                    Instant boundTwo = offsetTime(timeLimit, timeUnit, boundOne);
+                    return new ImmutablePair<>(boundOne, boundTwo);
+                }
             }
 
             case SPECIFIED: {


### PR DESCRIPTION
Prevent FIA from throwing an exception when an empty time series is queried (instantiated but does not have time series data)