### PR TITLE
Kok foong/6/combine metadata time series and trajectory data

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,18 +112,21 @@ The `time` object should contain the following parameters:
     - "first" (furthest back time value in RDB)
   Defaults to "now".
 
-The `trajectory` object should contain the following parameters, more descriptions of the file contents are given in [here](#trajectory-queries):
+For clarification, the `limit` value supports both positive and negative integers. For reference types of `now` and `latest` it is multiplied by **-1** then **added** to the reference time during the calculation of retrieval times. For references of `first` is is simply **added** to the reference time.
+
+For example, a value of `24` with a reference of `now` will provide all values generated within the last real-world day. Whereas a value of `24` with a reference of `first` will return all values generated between the first data point and one real-world day afterwards.
+
+The `trajectory` should be an array of JSON objects, where each of these objects should contain the following parameters:
 
 - Required:
   - `pointIriQuery`: Location of file with SPARQL query used to get point IRIs containing time series (relative to configuration file).
   - `featureIriQuery`: Location of file with SQL/SPARQL query to obtain the intersected feature IRIs (relative to configuration file).
   - `metaQuery`: Location of file with SPARQL query to obtain metadata of the intersected features (relative to configuration file).
+  - `database`: Database containing time series data of the points.
 
-For clarification, the `limit` value supports both positive and negative integers. For reference types of `now` and `latest` it is multiplied by **-1** then **added** to the reference time during the calculation of retrieval times. For references of `first` is is simply **added** to the reference time.
+More descriptions of the file contents are given in [here](#trajectory-queries).
 
-For example, a value of `24` with a reference of `now` will provide all values generated within the last real-world day. Whereas a value of `24` with a reference of `first` will return all values generated between the first data point and one real-world day afterwards.
-
-Within the [samples/fia/fia-config.json](./samples/fia/fia-config.json) file, a mock configuration can be found.
+Within the [sample/fia/fia-config.json](./sample/fia/fia-config.json) file, a mock configuration can be found.
 
 ### Expected query formats
 

--- a/code/src/main/java/com/cmclinnovations/featureinfo/QueryManager.java
+++ b/code/src/main/java/com/cmclinnovations/featureinfo/QueryManager.java
@@ -138,7 +138,18 @@ public class QueryManager {
             result.put("time", timedata);
         }
         if (trajectoryData != null && !trajectoryData.isEmpty()) {
-            result.put("meta", trajectoryData);
+            if (result.has("meta")) {
+                // append to existing metadata object
+                trajectoryData.keySet().forEach(k -> {
+                    if (metadata.has(k)) {
+                        LOGGER.warn("Trajectory data and metadata has the same label: {}", k);
+                    } else {
+                        metadata.put(k, trajectoryData.get(k));
+                    }
+                });
+            } else {
+                result.put("meta", trajectoryData);
+            }
         }
 
         return result;
@@ -149,7 +160,7 @@ public class QueryManager {
      * and which
      * configuration entries match said classes.
      * 
-     * @param iri      feature IRI.
+     * @param iri feature IRI.
      * 
      * @return Set of matching configuration entries.
      * 

--- a/code/src/main/java/com/cmclinnovations/featureinfo/config/ConfigEntry.java
+++ b/code/src/main/java/com/cmclinnovations/featureinfo/config/ConfigEntry.java
@@ -294,7 +294,7 @@ public class ConfigEntry {
                 String classIRI,
                 String metaQueryFile) throws IllegalArgumentException, IOException {
 
-            return build(id, classIRI, metaQueryFile, null, null, 0, null, null);
+            return build(id, classIRI, metaQueryFile, null, null, 0, null, null, null, null, null, null);
         }
 
         /**
@@ -322,7 +322,8 @@ public class ConfigEntry {
                 String timeLimitUnit,
                 String timeDatabase) throws IllegalArgumentException, IOException {
 
-            return build(id, classIRI, null, timeQueryFile, timeReference, timeLimitValue, timeLimitUnit, timeDatabase);
+            return build(id, classIRI, null, timeQueryFile, timeReference, timeLimitValue, timeLimitUnit, timeDatabase,
+                    null, null, null, null);
         }
 
         /**
@@ -350,7 +351,11 @@ public class ConfigEntry {
                 String timeReference,
                 int timeLimitValue,
                 String timeLimitUnit,
-                String timeDatabase) throws IllegalArgumentException, IOException {
+                String timeDatabase,
+                String pointIriQuery,
+                String featureIriQuery,
+                String metaQuery,
+                String trajectoryDatabase) throws IllegalArgumentException, IOException {
 
             // Check for valid parameters
             if (timeQueryFile != null && !timeQueryFile.isEmpty() && (timeDatabase == null || timeDatabase.isEmpty())) {
@@ -397,37 +402,11 @@ public class ConfigEntry {
 
             entry.timeDatabase = timeDatabase;
 
-            // Populate query contents
-            readQueryContent(entry);
-            return entry;
-        }
-
-        /**
-         * special case for trajectory query
-         * 
-         * @param id
-         * @param classIRI
-         * @param trajectoryQuery
-         * @param featureIriQuery
-         * @param metaQuery
-         * @return
-         * @throws IOException
-         */
-        public ConfigEntry build(
-                String id,
-                String classIRI,
-                String pointIriQuery,
-                String featureIriQuery,
-                String metaQuery,
-                String database) throws IOException {
-
-            // Create and return ConfigEntry instance.
-            ConfigEntry entry = new ConfigEntry(id);
-            entry.classIRI = classIRI;
+            // trajectory stuff
             entry.pointIriQueryFile = pointIriQuery;
             entry.featureIriQueryFile = featureIriQuery;
             entry.trajectoryMetaFile = metaQuery;
-            entry.trajectoryDatabase = database;
+            entry.trajectoryDatabase = trajectoryDatabase;
 
             // Populate query contents
             readQueryContent(entry);

--- a/code/src/main/java/com/cmclinnovations/featureinfo/config/ConfigReader.java
+++ b/code/src/main/java/com/cmclinnovations/featureinfo/config/ConfigReader.java
@@ -139,22 +139,25 @@ public class ConfigReader {
                 timeDatabase = timeEntry.optString("database");
             }
 
+            // Trajectory
+            JSONObject trajectoryEntry = jsonEntry.optJSONObject("trajectory");
+
+            String pointIriQuery = null;
+            String featureIriQuery = null;
+            String metaQuery = null;
+            String trajectoryDatabase = null;
+            if (trajectoryEntry != null) {
+                LOGGER.info("Detected trajectory config for {}", clazz);
+                // trajectory details
+                pointIriQuery = trajectoryEntry.getString("pointIriQuery");
+                featureIriQuery = trajectoryEntry.getString("featureIriQuery");
+                metaQuery = trajectoryEntry.getString("metaQuery");
+                trajectoryDatabase = trajectoryEntry.getString("database");
+            }
+
             // Build
-            return builder.build(id, clazz, metaFile, timeFile, timeReference, timeLimit, timeUnit, timeDatabase);
-        } else if (jsonEntry.has("trajectory")) { // special trajectory case
-            // TODO: in futrue, it would be best to do tragectory calculations all in a
-            // single sparql query. This requires the time series being kg accessible.
-            String id = jsonEntry.getString("id");
-            String clazz = jsonEntry.getString("class");
-
-            // trajectory details
-            JSONObject trajectoryEntry = jsonEntry.getJSONObject("trajectory");
-            String pointIriQuery = trajectoryEntry.getString("pointIriQuery");
-            String featureIriQuery = trajectoryEntry.getString("featureIriQuery");
-            String metaQuery = trajectoryEntry.getString("metaQuery");
-            String timeDatabase = trajectoryEntry.optString("database");
-
-            return builder.build(id, clazz, pointIriQuery, featureIriQuery, metaQuery, timeDatabase);
+            return builder.build(id, clazz, metaFile, timeFile, timeReference, timeLimit, timeUnit, timeDatabase,
+                    pointIriQuery, featureIriQuery, metaQuery, trajectoryDatabase);
         } else {
             // Assume old format entry
             String id = "entry-" + (entries.size() + 1);
@@ -171,7 +174,8 @@ public class ConfigReader {
             String timeDatabase = jsonEntry.optString("databaseName");
 
             // Build
-            return builder.build(id, clazz, metaFile, timeFile, timeReference, timeLimit, timeUnit, timeDatabase);
+            return builder.build(id, clazz, metaFile, timeFile, timeReference, timeLimit, timeUnit, timeDatabase, null,
+                    null, null, null);
         }
 
     }

--- a/code/src/main/java/com/cmclinnovations/featureinfo/config/ConfigReader.java
+++ b/code/src/main/java/com/cmclinnovations/featureinfo/config/ConfigReader.java
@@ -111,7 +111,7 @@ public class ConfigReader {
         // Initialise a new builder
         ConfigEntryBuilder builder = new ConfigEntryBuilder(configDir);
 
-        if (jsonEntry.has("meta") || jsonEntry.has("time")) {
+        if (jsonEntry.has("meta") || jsonEntry.has("time") || jsonEntry.has("trajectory")) {
             // New format entry
             String id = jsonEntry.getString("id");
             String clazz = jsonEntry.getString("class");
@@ -140,24 +140,17 @@ public class ConfigReader {
             }
 
             // Trajectory
-            JSONObject trajectoryEntry = jsonEntry.optJSONObject("trajectory");
-
-            String pointIriQuery = null;
-            String featureIriQuery = null;
-            String metaQuery = null;
-            String trajectoryDatabase = null;
-            if (trajectoryEntry != null) {
+            JSONArray trajectoryConfig;
+            if (jsonEntry.has("trajectory")) {
                 LOGGER.info("Detected trajectory config for {}", clazz);
-                // trajectory details
-                pointIriQuery = trajectoryEntry.getString("pointIriQuery");
-                featureIriQuery = trajectoryEntry.getString("featureIriQuery");
-                metaQuery = trajectoryEntry.getString("metaQuery");
-                trajectoryDatabase = trajectoryEntry.getString("database");
+                trajectoryConfig = jsonEntry.getJSONArray("trajectory");
+            } else {
+                trajectoryConfig = new JSONArray();
             }
 
             // Build
             return builder.build(id, clazz, metaFile, timeFile, timeReference, timeLimit, timeUnit, timeDatabase,
-                    pointIriQuery, featureIriQuery, metaQuery, trajectoryDatabase);
+                    trajectoryConfig);
         } else {
             // Assume old format entry
             String id = "entry-" + (entries.size() + 1);
@@ -174,8 +167,8 @@ public class ConfigReader {
             String timeDatabase = jsonEntry.optString("databaseName");
 
             // Build
-            return builder.build(id, clazz, metaFile, timeFile, timeReference, timeLimit, timeUnit, timeDatabase, null,
-                    null, null, null);
+            return builder.build(id, clazz, metaFile, timeFile, timeReference, timeLimit, timeUnit, timeDatabase,
+                    new JSONArray());
         }
 
     }

--- a/sample/fia/fia-config.json
+++ b/sample/fia/fia-config.json
@@ -3,7 +3,7 @@
         {
             "id": "Castle",
             "class": "https://theworldavatar.io/ontology/ontocastle/ontocastle.owl#Castle",
-            "meta" : {
+            "meta": {
                 "queryFile": "CastleMeta.sparql"
             },
             "time": {
@@ -17,16 +17,34 @@
         {
             "id": "Structure",
             "class": "https://theworldavatar.io/ontology/ontocastle/ontocastle.owl#Structure",
-            "meta" : {
+            "meta": {
                 "queryFile": "StructureMeta.sparql"
             }
         },
         {
             "id": "Feature",
             "class": "http://www.opengis.net/ont/geosparql#Feature",
-            "meta" : {
+            "meta": {
                 "queryFile": "FeatureMeta.sparql"
             }
+        },
+        {
+            "id": "Line",
+            "class": "https://www.theworldavatar.io/kg/trajectory/Trajectory",
+            "trajectory": [
+                {
+                    "pointIriQuery": "point_query.sparql",
+                    "featureIriQuery": "feature_query.sparql",
+                    "metaQuery": "trajectory_meta.sparql",
+                    "database": "postgres"
+                },
+                {
+                    "pointIriQuery": "point_query.sparql",
+                    "featureIriQuery": "feature_query.sql",
+                    "metaQuery": "trajectory_meta.sparql",
+                    "database": "postgres"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Changes are specific to the trajectory case:
- Modified format of trajectory info in fia-config.json so that it takes in an array, refer to linked [issue](https://github.com/TheWorldAvatar/Feature-Info-Agent/issues/6)
- Handles conversion between milliseconds/seconds due to the vis framework passing time bounds in seconds. Not super elegant but currently it is assumed that trajectory data will always be stored as epoch milliseconds or epoch seconds